### PR TITLE
Add Wordle restart button

### DIFF
--- a/apps/project-wordle/src/components/Banner/Banner.js
+++ b/apps/project-wordle/src/components/Banner/Banner.js
@@ -1,13 +1,19 @@
 import React from 'react';
 
-function Banner({ hasWon }) {
+function Banner({ hasWon, onRestart, tries }) {
   if (hasWon) {
     return (
       <div className="happy banner">
         <p>
           <strong>Congratulations!</strong> Got it in
-          <strong>3 guesses</strong>.
+          <strong>
+            {tries === 1 ? ' 1 guess' : ` ${tries} guesses`}
+          </strong>
+          .
         </p>
+        <button className="reset-button" onClick={onRestart}>
+          Restart Game
+        </button>
       </div>
     );
   }
@@ -17,6 +23,9 @@ function Banner({ hasWon }) {
       <p>
         Sorry, the correct answer is <strong>LEARN</strong>.
       </p>
+      <button className="reset-button" onClick={onRestart}>
+        Restart Button
+      </button>
     </div>
   );
 }

--- a/apps/project-wordle/src/components/Banner/Banner.js
+++ b/apps/project-wordle/src/components/Banner/Banner.js
@@ -24,7 +24,7 @@ function Banner({ hasWon, onRestart, tries }) {
         Sorry, the correct answer is <strong>LEARN</strong>.
       </p>
       <button className="reset-button" onClick={onRestart}>
-        Restart Button
+        Restart Game
       </button>
     </div>
   );

--- a/apps/project-wordle/src/components/Game/Game.js
+++ b/apps/project-wordle/src/components/Game/Game.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Guess from '../Guess/Guess';
 import Banner from '../Banner/Banner';
 import { checkGuess } from '../../game-helpers';
@@ -6,18 +6,22 @@ import { sample } from '../../utils';
 import { WORDS } from '../../data';
 import { NUM_OF_GUESSES_ALLOWED } from '../../constants';
 
-// Pick a random word on every pageload.
-const answer = sample(WORDS);
-// To make debugging easier, we'll log the solution in the console.
-console.info({ answer });
-
 function Game() {
+  const [answer, setAnswer] = useState(() => sample(WORDS));
   const [guesses, setGuesses] = useState([]);
   const [guessInput, setGuessInput] = useState('');
   const hasWon =
     guesses.length > 0 &&
     guesses[guesses.length - 1].map((a) => a.letter).join('') ===
       answer;
+
+  // To make debugging easier, we'll log the solution in the console.
+  console.info({ answer });
+
+  const onRestart = useCallback(() => {
+    setGuesses([]);
+    setAnswer(sample(WORDS));
+  }, []);
 
   return (
     <div>
@@ -60,7 +64,11 @@ function Game() {
         />
       </form>
       {(guesses.length === NUM_OF_GUESSES_ALLOWED || hasWon) && (
-        <Banner hasWon={hasWon} />
+        <Banner
+          hasWon={hasWon}
+          onRestart={onRestart}
+          tries={guesses.length}
+        />
       )}
     </div>
   );

--- a/apps/project-wordle/src/styles.css
+++ b/apps/project-wordle/src/styles.css
@@ -185,6 +185,12 @@ h1 {
   color: white;
 }
 
+.reset-button {
+  border-radius: 2rem;
+  border: 1px solid #ffffff;
+  padding: 0.5rem 1rem;
+}
+
 .visually-hidden {
   position: absolute;
   overflow: hidden;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Restart Game" button to both winning and losing banners, allowing users to restart the game directly from the banner.
  - The banner now displays the number of guesses taken, with correct singular/plural wording.

- **Style**
  - Introduced new styling for the restart button to enhance its appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->